### PR TITLE
Integrate IPC pluggable infrastructure

### DIFF
--- a/ipc/loader.py
+++ b/ipc/loader.py
@@ -1,0 +1,37 @@
+#
+#  Copyright (C) 2017, Jaguar Land Rover
+#
+#  This program is licensed under the terms and conditions of the
+#  Mozilla Public License, version 2.0.  The full text of the 
+#  Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+#
+
+import inspect
+import importlib
+
+def _load_module(modulename):
+    try:
+        return importlib.import_module(modulename)
+    except ImportError:
+        print("Error loading module: {}".format(modulename))
+        raise
+
+def _exist_method(module, method):
+    return hasattr(module, method) and inspect.isroutine(getattr(module, method))
+
+def load_plugin(modulename):
+    # Load plugin module.
+    module = _load_module(modulename)
+
+    # Inspect caller module.
+    caller_info = inspect.stack()[1]
+    caller_module = inspect.getmodule(caller_info[0])
+
+    # Override receive/send functions _only_ if they both exist
+    # in the caller and plugin module.
+    if _exist_method(caller_module, 'receive') and \
+       _exist_method(module, 'receive'):
+        caller_module.receive = module.receive
+
+    if _exist_method(caller_module, 'send') and _exist_method(module, 'send'):
+        caller_module.send = module.send

--- a/ipc/zeromq.py
+++ b/ipc/zeromq.py
@@ -1,0 +1,50 @@
+#
+#  Copyright (C) 2017, Collabora Ltd.
+#
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this file,
+#  You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+
+import os
+import zmq
+import os.path
+
+IPC_SOCKET_PATH = os.path.join(os.environ['XDG_RUNTIME_DIR'], "vsm-ipc.socket")
+IPC_SOCKET = "ipc://{}".format(IPC_SOCKET_PATH)
+
+def _send(signal, value):
+    context = zmq.Context()
+    socket = context.socket(zmq.REQ)
+    socket.connect(IPC_SOCKET)
+
+    # Send Python tuple: (Signal ID, Signal Value).
+    socket.send_pyobj((signal, value))
+
+    # Wait for receiver reply.
+    socket.recv()
+
+def _receive():
+    context = zmq.Context()
+    socket = context.socket(zmq.REP)
+    socket.bind(IPC_SOCKET)
+
+    # Receive Python object: (Signal ID, Signal Value).
+    msg = socket.recv_pyobj()
+
+    # Send 1 byte as a reply to the client.
+    socket.send(bytes(1))
+    return msg
+
+#
+# The module public interface consists of the following functions:
+#
+# send    - Function to send signal
+# receive - Function that receives signal.
+#           It returns the received message as a tuple of (ID, Value).
+#
+def send(signal, value):
+    _send(signal, value)
+
+def receive():
+    return _receive()

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=[''],
+    install_requires=['pyzmq'],
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,

--- a/tests/test_receiver.py
+++ b/tests/test_receiver.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3.5m
+#
+#  Copyright (C) 2017, Jaguar Land Rover
+#
+#  This program is licensed under the terms and conditions of the
+#  Mozilla Public License, version 2.0.  The full text of the 
+#  Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+#
+
+import unittest
+from ipc.loader import load_plugin
+
+def receive():
+    """This method will be overloaded by the plugin"""
+    pass
+
+class TestReceiver(unittest.TestCase):
+
+    def setUp(self):
+        print(self._testMethodName)
+        load_plugin('ipc.zeromq')
+
+    def test_receiver(self):
+        i = 0
+        while i < 3:
+            signal, value = receive()
+            print("received: {} , {}".format(signal, value))
+            i += 1
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_sender.py
+++ b/tests/test_sender.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3.5m
+#
+#  Copyright (C) 2017, Jaguar Land Rover
+#
+#  This program is licensed under the terms and conditions of the
+#  Mozilla Public License, version 2.0.  The full text of the 
+#  Mozilla Public License is at https://www.mozilla.org/MPL/2.0/
+#
+
+import unittest
+from ipc.loader import load_plugin
+
+def send(signal, value):
+    """This method will be overloaded by the plugin"""
+    pass
+
+class TestSender(unittest.TestCase):
+
+    def setUp(self):
+        print(self._testMethodName)
+        load_plugin('ipc.zeromq')
+
+    def test_sender(self):
+        # Send signals with different value types.
+        for signal in [ "car.backup" , "volume.up" , "car.stop" ]:
+            send(signal, None)
+            print("sent:", signal)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit integrates the IPC pluggable infrastructure
and an IPC (ZeroMQ) module that can be loaded using such
a mechanism.

It extends the vsm script to accept the '--ipc-module'
option to switch between the default stdin/stodut module
and the ZeroMQ IPC module.

It includes tests for the receiver and sender, which will
test that the pluggable mechanism works as expected and also
test sending/receiving signals using the zeromq module.

Signed-off-by: Luis Araujo <luis.araujo@collabora.co.uk>